### PR TITLE
Fix LED flickering issue

### DIFF
--- a/gu-core/gu-core.ino
+++ b/gu-core/gu-core.ino
@@ -1,98 +1,129 @@
 #include <Servo.h>
 
-const int ledPin = 5;
-const int servoPin = 9;
-const int buttonPin = 7;
+// Pin definitions
+const int PIN_LED = 5;
+const int PIN_SERVO = 9;
+const int PIN_BUTTON = 7;
 
-const int fadeAmount = 2;
-const int servoAmount = 2;
+// Constants used to change physical output values
+const int DIFF_LED_BRIGHTNESS = 2;
+const int DIFF_SERVO_ROTATION = 2;
 
-const int maxRotationChanges = 6;
-const int maxRotation = 180;
-const int maxBrightness = 255;
+// Maximum values
+const int MAX_ROTATION_CHANGES = 6;
+const int MAX_SERVO_ANGLE = 180;
+const int MAX_LED_BRIGHTNESS = 255;
 
-const long ledInterval = 25;
-const long servoInterval = 15;
+// Time intervals (in msec) between updating output values
+const long LED_UPDATE_INTERVAL = 25;
+const long SERVO_UPDATE_INTERVAL = 15;
 
-unsigned long ledLastMsec = 0;
-unsigned long servoLastMsec = 0;
+// Last update timestamps for updating output values
+unsigned long lastTimestampLed = 0;
+unsigned long lastTimestampServo = 0;
 
-int brightness = fadeAmount;
-int currentFadeAmount = fadeAmount;
+// Current LED control values
+int currentBrightness = DIFF_LED_BRIGHTNESS;
+int currentBrightnessDiff = DIFF_LED_BRIGHTNESS;
 
-int servoPosition = 0;
-int currentMovementAmount = servoAmount;
+// Current servo control values
+int currentServoAngle = 0;
+int currentServoAngleDiff = DIFF_SERVO_ROTATION;
+short headRotationsRemaining = 0;
 
+// Button input control value
 int buttonState = 0;
-short rotateCount = 0;
-
-bool locked = false;
+bool preventRetrigger = false;
 
 Servo mainServo;
 
+/*
+ * Initial setup
+ */
 void setup() {
-  pinMode(ledPin, OUTPUT);
-  pinMode(buttonPin, INPUT);
+  pinMode(PIN_LED, OUTPUT);
+  pinMode(PIN_BUTTON, INPUT);
 
-  mainServo.attach(servoPin);
-  servoPosition = mainServo.read();
+  mainServo.attach(PIN_SERVO);
+  currentServoAngle = mainServo.read();
 }
 
 /*
+ * Controls the fading of the LED, up to a maximum value
  *
+ * @param currentTimestamp: unsigned long - current timestamp, in msec
+ * @param maximumBrightness: int - maximum brightness, 0 - 255
  */
-void ledFadeControl(unsigned long currentMillis) {
-  if (currentMillis - ledLastMsec < ledInterval) {
+void ledFadeControl(unsigned long currentTimestamp, int maximumBrightness) {
+  if (currentTimestamp - lastTimestampLed < LED_UPDATE_INTERVAL) {
     return;
   }
 
-  ledLastMsec = currentMillis;
+  lastTimestampLed = currentTimestamp;
 
-  analogWrite(ledPin, brightness);
-  brightness += currentFadeAmount;
+  // Sanity check - if over maximum brightness, fade out
+  if (currentBrightness > maximumBrightness) {
+    currentBrightnessDiff = -DIFF_LED_BRIGHTNESS;
+  }
 
-  if (brightness < fadeAmount || brightness > maxBrightness - fadeAmount) {
-    currentFadeAmount = -currentFadeAmount;
+  currentBrightness += currentBrightnessDiff;
+  analogWrite(PIN_LED, currentBrightness);
+
+  // Flip difference sign when at extremities
+  if (currentBrightness < DIFF_LED_BRIGHTNESS || currentBrightness >  - DIFF_LED_BRIGHTNESS) {
+    currentBrightnessDiff = -currentBrightnessDiff;
   }
 }
 
 /*
+ * Controls the rotation of the servo
  *
+ * @param currentTimestamp: unsigned long - current timestamp, in msec
  */
-void servoControl(unsigned long currentMillis) {
-  if (currentMillis - servoLastMsec < servoInterval) {
+void servoControl(unsigned long currentTimestamp) {
+  if (currentTimestamp - lastTimestampServo < SERVO_UPDATE_INTERVAL) {
     return;
   }
 
-  servoLastMsec = currentMillis;
+  lastTimestampServo = currentTimestamp;
 
-  mainServo.write(servoPosition);
-  servoPosition += currentMovementAmount;
+  currentServoAngle += currentServoAngleDiff;
+  mainServo.write(currentServoAngle);
 
-  if (servoPosition < servoAmount || servoPosition > maxRotation - servoAmount) {
-    currentMovementAmount = -currentMovementAmount;
+  // Flip difference sign when at extremities and decrease head rotation count
+  if (currentServoAngle < DIFF_SERVO_ROTATION || currentServoAngle > MAX_SERVO_ANGLE - DIFF_SERVO_ROTATION) {
+    currentServoAngleDiff = -currentServoAngleDiff;
+    headRotationsRemaining--;
   }
 }
 
 /*
- *
+ * Main loop
  */
 void loop() {
-  buttonState = digitalRead(buttonPin);
+  buttonState = digitalRead(PIN_BUTTON);
 
-  if (buttonState == HIGH && !locked) {
-    rotateCount = maxRotationChanges;
-    brightness = maxBrightness;
-    currentFadeAmount = -fadeAmount;
-    analogWrite(ledPin, brightness);
-    locked = true;
+  // Only trigger if button pressed and not currently triggered
+  if (buttonState == HIGH && !preventRetrigger) {
+    preventRetrigger = true;
+    headRotationsRemaining = MAX_ROTATION_CHANGES;
+
+    // Reset LED control to fade in
+    currentBrightnessDiff = DIFF_LED_BRIGHTNESS;
   }
 
-  unsigned long currentMillis = millis();
-  if (rotateCount > 0) {
-    servoControl(currentMillis);
+  unsigned long currentTimestamp = millis();
+  int currentMaxLedBrightness;
+
+  if (headRotationsRemaining > 0) {
+    // Guardian active state"
+    currentMaxLedBrightness = MAX_LED_BRIGHTNESS;
+    servoControl(currentTimestamp);
   } else {
-    ledFadeControl(currentMillis);
-    locked = false;
+    // Guardian sleeping state
+    currentMaxLedBrightness = MAX_LED_BRIGHTNESS / 2;
+    preventRetrigger = false;
   }
+
+  ledFadeControl(currentTimestamp, currentMaxLedBrightness);
 }

--- a/gu-core/gu-core.ino
+++ b/gu-core/gu-core.ino
@@ -61,17 +61,14 @@ void ledFadeControl(unsigned long currentTimestamp, int maximumBrightness) {
 
   lastTimestampLed = currentTimestamp;
 
-  // Sanity check - if over maximum brightness, fade out
-  if (currentBrightness > maximumBrightness) {
-    currentBrightnessDiff = -DIFF_LED_BRIGHTNESS;
-  }
-
   currentBrightness += currentBrightnessDiff;
   analogWrite(PIN_LED, currentBrightness);
 
-  // Flip difference sign when at extremities
-  if (currentBrightness < DIFF_LED_BRIGHTNESS || currentBrightness >  - DIFF_LED_BRIGHTNESS) {
-    currentBrightnessDiff = -currentBrightnessDiff;
+  // Set difference sign when over extremities
+  if (currentBrightness < DIFF_LED_BRIGHTNESS) {
+    currentBrightnessDiff = DIFF_LED_BRIGHTNESS;
+  } else if (currentBrightness > maximumBrightness - DIFF_LED_BRIGHTNESS) {
+    currentBrightnessDiff = -DIFF_LED_BRIGHTNESS;
   }
 }
 

--- a/gu-core/gu-core.ino
+++ b/gu-core/gu-core.ino
@@ -118,7 +118,7 @@ void loop() {
     servoControl(currentTimestamp);
   } else {
     // Guardian sleeping state
-    currentMaxLedBrightness = MAX_LED_BRIGHTNESS / 2;
+    currentMaxLedBrightness = MAX_LED_BRIGHTNESS / 8;
     preventRetrigger = false;
   }
 


### PR DESCRIPTION
LED was flickering due to incorrect logic controlling when to change fade direction that revolved around negating the value of the brightness variable if the value was out of bounds. Unfortunately this negation was being done multiple times if the value remained out of bounds.

This change fixes the logic to explicitly set the sign of the control variable when out of bounds. It also makes the code more readable by renaming variables.